### PR TITLE
Add an OpenNebula talk and an OpenNebula workshop

### DIFF
--- a/content/proposals/enterprise-cloud-with-opennebula/index.md
+++ b/content/proposals/enterprise-cloud-with-opennebula/index.md
@@ -1,0 +1,17 @@
+title: OpenNebula Fundamentals
+status: hidden
+category: proposals
+
+Abstract
+---------
+The goal of this tutorial is to provide a global overview of the process of installing, configuring and operating private, public and hybrid clouds using OpenNebula. Additionally the program briefly addresses the integration of [OpenNebula](http://opennebula.org) with other components in the data center.
+
+Speaker
+-------
+Jaime Melis <jmelis@opennebula.org>
+
+Jaime Melis has been part of the OpenNebula team for the last 3 years, as core engineer of the cloud management platform. He has been involved in several EU-funded flagship projects in cloud computing, like RESERVOIR, NUBA, and BonFIRE.
+
+Slides
+------
+will be added after talk

--- a/content/proposals/opennebula-fundamentals/index.md
+++ b/content/proposals/opennebula-fundamentals/index.md
@@ -1,0 +1,18 @@
+title: Building Your Enterprise Cloud with OpenNebula
+status: hidden
+category: proposals
+
+Abstract
+---------
+[OpenNebula](http://opennebula.org) is a fully open-source cloud management platform, with excellent performance and scalability to manage tens of thousands of virtual machines, and with the most advanced functionality for building virtualized data centers and enterprise cloud infrastructures. OpenNebula is the result of many years of research and development in efficient and scalable management of virtual machines on large-scale distributed infrastructures. The presentation will describe the OpenNebula project with a focus on its unique features to build and manage enterprise clouds. The target audience is devops and system administrators
+interested in deploying a private cloud solution, or in the integration of OpenNebula with other platform. Although this is not a hands-on tutorial, by the end of the presentation attendees will have a comprehensive idea of the integration and customization capabilities of OpenNebula in different areas, like user authentication, virtualization, storage, networking, etc.
+
+Speaker
+-------
+Jaime Melis <jmelis@opennebula.org>
+
+Jaime Melis has been part of the OpenNebula team for the last 3 years, as core engineer of the cloud management platform. He has been involved in several EU-funded flagship projects in cloud computing, like RESERVOIR, NUBA, and BonFIRE.
+
+Slides
+------
+will be added after talk


### PR DESCRIPTION
This commit introduces a talk and a workshop about OpenNebula for the Loadays event.

Ideally the talk would be held on saturday, about 1 hour long, and the workshop on sunday for about 4 hours long.
